### PR TITLE
Basic api

### DIFF
--- a/puppy/__init__.py
+++ b/puppy/__init__.py
@@ -1,0 +1,3 @@
+from .browser import Browser
+
+__all__ = ['Browser']

--- a/puppy/browser.py
+++ b/puppy/browser.py
@@ -16,15 +16,14 @@ from .utils import get_free_port
 
 
 class Browser:
-
     def __init__(self,
                  headless=True,
                  proxy_uri=None,
+                 user_agent=None,
                  user_data_dir=None,
                  executable_path=None,
                  debug=False,
-                 *args,
-                 **kwargs):
+                 args=None):
         if not executable_path:
             executable_path = get_executable_path()
             if not os.path.exists(executable_path):
@@ -36,8 +35,14 @@ class Browser:
             '--remote-debugging-port={}'.format(self._port)
         ]
 
+        if args is not None:
+            cmd.extend(args)
+
         if headless is True:
             cmd.append('--headless')
+
+        if user_agent is not None:
+            cmd.append('--user-agent={}'.format(user_agent))
 
         self._tmp_user_data_dir = None
         if user_data_dir is None:

--- a/puppy/connection.py
+++ b/puppy/connection.py
@@ -100,7 +100,8 @@ class Connection:
         if self._debug:  # TODO: set up a logger and format this nicely
             print('sent -- ', json.dumps(message))
         self._ws.send(json.dumps(message))
-        event_.wait(timeout=MESSAGE_TIMEOUT)
+        if not event_.wait(timeout=MESSAGE_TIMEOUT):
+            raise BrowserError('Timed out waiting for response from browser')
         if 'error' in self.messages[id_]:
             raise BrowserError(self.messages[id_]['error'])
         else:

--- a/puppy/connection.py
+++ b/puppy/connection.py
@@ -10,6 +10,9 @@ from .exceptions import BrowserError
 from .session import Session
 
 
+MESSAGE_TIMEOUT = 300
+
+
 class Connection:
     def __init__(self, endpoint, debug=False):
         self.endpoint = endpoint
@@ -97,7 +100,7 @@ class Connection:
         if self._debug:  # TODO: set up a logger and format this nicely
             print('sent -- ', json.dumps(message))
         self._ws.send(json.dumps(message))
-        event_.wait()
+        event_.wait(timeout=MESSAGE_TIMEOUT)
         if 'error' in self.messages[id_]:
             raise BrowserError(self.messages[id_]['error'])
         else:

--- a/puppy/exceptions.py
+++ b/puppy/exceptions.py
@@ -1,2 +1,6 @@
 class BrowserError(Exception):
     pass
+
+
+class PageError(Exception):
+    pass

--- a/puppy/js_object.py
+++ b/puppy/js_object.py
@@ -103,3 +103,18 @@ class Element(JSObject):
         self._page.session.send('Input.dispatchMouseEvent', type='mouseMoved', x=mean_x, y=mean_y)
         self._page.session.send('Input.dispatchMouseEvent', type='mousePressed', x=mean_x, y=mean_y, button='left', clickCount=1)
         self._page.session.send('Input.dispatchMouseEvent', type='mouseReleased', x=mean_x, y=mean_y, button='left', clickCount=1)
+
+    @property
+    def is_visible(self):
+        style = self._remote_call('window.getComputedStyle', [self])
+        visibility = style._prop('visibility')
+        has_visible_bounding_box = self._remote_call(
+            '''
+            (element) => {
+                const rect = element.getBoundingClientRect();
+                return !!(rect.top || rect.bottom || rect.width || rect.height);
+            }
+            ''',
+            [self]
+        )
+        return visibility != 'hidden' and has_visible_bounding_box

--- a/puppy/page.py
+++ b/puppy/page.py
@@ -232,7 +232,7 @@ class Page:
             timeout (int, optional): The number of seconds to wait before throwing an error.
 
         Returns:
-            None.
+            A list of elements matching the xpath expression.
 
         Raises:
             PageError: If no matching element is found before the given timeout.
@@ -243,10 +243,15 @@ class Page:
         while slept < timeout:
             element_list = self.xpath(xpath_expr)
             if element_list:
-                return element_list
+                if visible:
+                    visible_elements = [e for e in element_list if e.is_visible]
+                    if len(visible_elements):
+                        return visible_elements
+                else:
+                    return element_list
             time.sleep(interval)
             slept += interval
-        raise PageError('Timed out waiting for element at %s' % xpath_expr)
+        raise PageError('Timed out waiting for element at `%s`' % xpath_expr)
 
     def xpath(self, expression):
         """Search the current page for elements matching an xpath expression.

--- a/puppy/page.py
+++ b/puppy/page.py
@@ -1,9 +1,13 @@
-import json
 import time
 
+from contextlib import contextmanager
+
+from .exceptions import BrowserError, PageError
 from .js_object import Element
 from .lifecycle_watcher import LifecycleWatcher
+from .request import Request
 from .request_manager import RequestManager
+from .response import Response
 
 
 class Page:
@@ -11,53 +15,228 @@ class Page:
         self._proxy_uri = proxy_uri
         self._target_id = target_id
         self._connection = connection
-        self._lifecycle_watcher = LifecycleWatcher(self)
         self._request_manager = RequestManager(self, self._proxy_uri)
 
-        self.responses = []
         self.closed = False
 
+        self._requests_by_url = {}
+        self._requests_by_id = {}
+        self._frames = {}
+
+        self._loader_id = None
+        self._frame_id = None
+        self._navigation_url = None
+
         self.session = self.create_devtools_session()
+
         self.session.send('Network.enable', enabled=True)
+        self.session.on('Network.requestWillBeSent', self._on_request_will_be_sent)
+        self.session.on('Network.responseReceived', self._on_response_recieved)
+
+        self.session.send('Page.enable', enabled=True)
+        self.session.send('Page.setLifecycleEventsEnabled', enabled=True)
+        self.session.on('Page.lifecycleEvent', self._on_lifecycle_event)
+
+        self.session.on('Page.frameNavigated', self._on_frame_navigated)
 
     # Public API #
-    # TODO: Documentation
 
-    def goto(self, url, wait_until='load', timeout=30):
-        if wait_until not in LifecycleWatcher.LIFECYCLE_EVENTS:
-            raise Exception('Invalid wait_until')
-        res = self.session.send('Page.navigate', url=url)
-        self._lifecycle_watcher.wait_for_event(res['loaderId'], wait_until, timeout)
+    def click(self, xpath_expression):
+        """Click an element on the page.
+
+        Args:
+            xpath_expression (str): The expression to search the page for. The first matching element will
+                be clicked.
+
+        Returns:
+            None.
+
+        Raises:
+            PageError: If no matching elements are found.
+        """
+        # TODO: Should this take xpath, css seclector, or both?
+        element_list = self.xpath(xpath_expression)
+        # TODO: Can we check if the element is clickable?
+        if not len(element_list):
+            raise PageError('Element with xpath %s does not exist' % xpath_expression)
+        element_list[0].click()
+
+    def close(self):
+        """Close the page."""
+        if self.closed:
+            return
+        self.closed = True
+        response = self._connection.send('Target.closeTarget', targetId=self._target_id)
+        if not response['success']:
+            raise BrowserError('Could not close page')
 
     def content(self):
+        """Get the page's rendered HTML content.
+
+        Returns:
+           The rendered HTML of the current page.
+        """
         return self.document._prop('documentElement').html
 
+    def create_devtools_session(self):
+        """Create a new session to send messages to the running Chrome devtools server."""
+        return self._connection.new_session(self._target_id)
+
+    @property
+    def document(self):
+        """An Element representing the current page's `document` object."""
+        response = self.evaluate('document')
+        return Element(response['objectId'], response['description'], self)
+
     def evaluate(self, expression):
+        """Send an expression to be evaluated in the browser's JavaScript console.
+
+        Args:
+           expression (str): The javascript expression to evaluate.
+
+        Returns:
+           The result returned by the remote code execution. Could be an int, str, bool, or None
+           if the remote code returns a primitive type, or a dict describing a remote object if
+           the code returns a complex type.
+        """
         response = self.session.send('Runtime.evaluate', expression=expression)
-        if 'result' not in response:
-            # TODO: Maybe sometimes there is expected to be no result?
-            raise Exception('no result in {}'.format(json.dumps(response)))
         if 'value' in response['result']:
             return response['result']['value']
         else:
             return response['result']
 
-    @property
-    def document(self):
-        response = self.evaluate('document')
-        return Element(response['objectId'], response['description'], self)
+    def evaluate_on_new_document(self, script):
+        """Set a script to be evaluated on each new page visiti.
 
-    def xpath(self, expression):
-        return self.document.xpath(expression)
+        Args:
+            script (str): The javascript code to evaluate.
 
-    def click(self, xpath_expression):
+        Returns:
+            None.
+        """
+        self.session.send('Page.addScriptToEvaluateOnNewDocument', source=script)
+
+    # TODO: implement referer
+    def goto(self,
+             url,
+             timeout=30,
+             wait_until='load'):
+        """Visit a url.
+
+        Args:
+            url (str): The url to visit.
+            timeout (int, optional): Maximum number of seconds to wait for the navigation to finish. Defaults to 30.
+            wait_until (str, optional): When to consider the navigation as having succeeded. Defaults to "load".
+
+        Returns:
+            The response recieved for the navigation request.
+        """
+        lifecyle_watcher = LifecycleWatcher(self, wait_until)
+        self.session.send('Page.navigate', url=url)
+        lifecyle_watcher.wait(timeout)
+        if self._navigation_url in self._requests_by_url:
+            return self._requests_by_url[self._navigation_url].response
+
+    def focus(self, xpath_expression):
+        """Focus an element on the page.
+
+        Args:
+            xpath_expression (str): The expression to search the page for. The first matching element will
+                be focused.
+
+        Returns:
+            None.
+
+        Raises:
+            PageError: If no matching elements are found.
+        """
         element_list = self.xpath(xpath_expression)
-        # TODO: Raise error if element is not clickable.
         if not len(element_list):
-            raise Exception(f'Element with xpath {xpath_expression} does not exist')
-        element_list[0].click()
+            raise PageError('Element with xpath %s does not exist' % xpath_expression)
+        element_list[0].focus()
+
+    def reload(self):
+        """Refresh the page."""
+        with self.wait_for_navigation(wait_until='load'):
+            self.session.send('Page.reload')
+
+    @property
+    def requests(self):
+        """All the requests this page has made."""
+        return list(self._requests_by_url.values())
+
+    def select(self, selector):
+        """Search the current page for elements matching a CSS selector.
+
+        Args:
+            selector (str): The CSS selector expression to search for.
+
+        Returns:
+            A list of Element objects representing the HTML nodes found on the page.
+        """
+        return self.document.querySelectorAll(selector)
+
+    def type(self, xpath_expression, text, delay=0):
+        """Give an element focus, then simulate a series of keyboard events.
+
+        Args:
+            xpath_expression (str): The expression to search the page for. The first matching element will
+                be focused.
+            text (str): The text to type. The text will be typed by sending a keypress event for each character
+                in the string.
+            delay (int, optional): The number of seconds to delay between each keypress. Defaults to 0.
+
+        Returns:
+            None.
+
+        Raises:
+            PageError: If no matching elements are found.
+        """
+        self.focus(xpath_expression)
+        for char in text:
+            time.sleep(delay)
+            self.session.send('Input.dispatchKeyEvent', type='char', text=char)
+
+    def url(self):
+        """Return the URL of the current page."""
+        response = self.session.send('Target.getTargetInfo', targetId=self._target_id)
+        return response.get('targetInfo', {}).get('url')
+
+    @contextmanager
+    def wait_for_navigation(self, wait_until='load', timeout=30):
+        """A context manager used to run a command and pause execution until the page completes
+           a navigation. Useful, for example, for waiting for a navigation to finish after clicking
+           a link on the page:
+
+           ```
+           with page.wait_for_navigation():
+               page.click('*//a[@id="nav-link"]')
+           ```
+
+        Args:
+            wait_until (str, optional): When to consider the navigation as having succeeded. Defaults to "load".
+            timeout (int, optional): Maximum number of seconds to wait for the navigation to finish. Defaults to 30.
+        """
+        lifecycle_watcher = LifecycleWatcher(self, wait_until, False)
+        yield
+        lifecycle_watcher.wait(timeout)
 
     def wait_for_xpath(self, xpath_expr, visible=False, timeout=30):
+        """Pause execution until an element is present on the page.
+
+        Args:
+            xpath_expression (str): The xpath expression to wait for. When at least one matching element is
+                found, waiting will end.
+            visible (bool, optional): If True, don't match elements that have `display: none` or
+                `visibility: hidden` CSS properties.
+            timeout (int, optional): The number of seconds to wait before throwing an error.
+
+        Returns:
+            None.
+
+        Raises:
+            PageError: If no matching element is found before the given timeout.
+        """
         slept = 0.0
         interval = 0.1
         element_list = []
@@ -67,49 +246,48 @@ class Page:
                 return element_list
             time.sleep(interval)
             slept += interval
-        raise Exception('Timed out waiting for {}'.format(xpath_expr))
+        raise PageError('Timed out waiting for element at %s' % xpath_expr)
 
-    def reload(self):
-        self.session.send('Page.reload')
-        # TODO: need to wait for navigation here
-        time.sleep(3)
+    def xpath(self, expression):
+        """Search the current page for elements matching an xpath expression.
 
-    # TODO: This is not how puppeteer implements this; verify it actually works
-    def url(self):
-        response = self.session.send('Target.getTargetInfo', targetId=self._target_id)
-        return response.get('targetInfo', {}).get('url')
+        Args:
+            expression (str): The xpath expression to search for.
 
-    def track_network_responses(self):
-        self.session.send('Network.enable', enabled=True)
-
-        def _on_response_received(**kwargs):
-            response = kwargs['response']
-            try:
-                res = self.session.send('Network.getResponseBody', requestId=kwargs['requestId'])
-                body = res['body']
-            except Exception:
-                body = None
-            self.responses.append({
-                'url': response['url'],
-                'status': response['status'],
-                'body': body
-            })
-
-        self.session.on('Network.responseReceived', _on_response_received)
-
-    def create_devtools_session(self):
-        return self._connection.new_session(self._target_id)
-
-    def close(self):
-        if self.closed:
-            return
-        self.closed = True
-        response = self._connection.send('Target.closeTarget', targetId=self._target_id)
-        if not response['success']:
-            raise Exception('Could not close page')
+        Returns:
+            A list of Element objects representing the HTML nodes found on the page.
+        """
+        return self.document.xpath(expression)
 
     def blacklist_url_patterns(self, *args):
         self._request_manager.blacklist_url_patterns(*args)
 
     def blacklist_resource_types(self, *args):
         self._request_manager.blacklist_resource_types(*args)
+
+    # Private methods
+    def _on_request_will_be_sent(self, **kwargs):
+        request = Request(kwargs['request'], kwargs['requestId'])
+        self._requests_by_id[request.request_id] = request
+        self._requests_by_url[request.url] = request
+
+    def _on_response_recieved(self, **kwargs):
+        request_id = kwargs['requestId']
+        request = self._requests_by_id.get(request_id)
+        if request is not None:
+            response = Response(kwargs['response'], request, self)
+            request.set_response(response)
+
+    @property
+    def loader_id(self):
+        return self._loader_id
+
+    def _on_lifecycle_event(self, **kwargs):
+        if kwargs['name'] == 'init':
+            self._loader_id = kwargs['loaderId']
+
+    def _on_frame_navigated(self, **kwargs):
+        is_main_frame = not bool(kwargs.get('parentId'))
+        if is_main_frame:
+            self._frame_id = kwargs['frame']['id']
+            self._navigation_url = kwargs['frame']['url']

--- a/puppy/request.py
+++ b/puppy/request.py
@@ -1,0 +1,32 @@
+class Request:
+    def __init__(self, request_data, request_id):
+        self._request_data = request_data
+        self._response = None
+        self._request_id = request_id
+
+    @property
+    def request_id(self):
+        return self._request_id
+
+    @property
+    def headers(self):
+        return self._request_data.get('headers')
+
+    @property
+    def method(self):
+        return self._request_data.get('method')
+
+    @property
+    def post_data(self):
+        return self._request_data.get('postData')
+
+    @property
+    def response(self):
+        return self._response
+
+    @property
+    def url(self):
+        return self._request_data.get('url')
+
+    def set_response(self, response):
+        self._response = response

--- a/puppy/response.py
+++ b/puppy/response.py
@@ -1,0 +1,29 @@
+class Response:
+    def __init__(self, response_data, request, page):
+        self._response_data = response_data
+        self._page = page
+        self.request = request
+
+    @property
+    def url(self):
+        return self._response_data['url']
+
+    @property
+    def status(self):
+        return self._response_data['status']
+
+    @property
+    def status_text(self):
+        return self._response_data['statusText']
+
+    @property
+    def headers(self):
+        return self._response_data['headers']
+
+    @property
+    def mime_type(self):
+        return self._response_data['mimeType']
+
+    def text(self):
+        response = self._page.session.send('Network.getResponseBody', requestId=self.request.request_id)
+        return response.get('body')

--- a/puppy/session.py
+++ b/puppy/session.py
@@ -6,6 +6,9 @@ from threading import Event, Thread
 from .exceptions import BrowserError
 
 
+MESSAGE_TIMEOUT = 300
+
+
 class Session:
     def __init__(self, connection, session_id):
         self._connection = connection
@@ -54,7 +57,8 @@ class Session:
         self._connection.send('Target.sendMessageToTarget',
                               message=json.dumps(message),
                               sessionId=self._session_id)
-        event_.wait()
+        if not event_.wait(timeout=MESSAGE_TIMEOUT):
+            raise BrowserError('Timed out waiting for response from browser')
         if 'error' in self.messages[id_]:
             raise BrowserError(self.messages[id_]['error'])
         else:

--- a/puppy/session.py
+++ b/puppy/session.py
@@ -56,7 +56,6 @@ class Session:
                               sessionId=self._session_id)
         event_.wait()
         if 'error' in self.messages[id_]:
-            # print(BrowserError(self.messages[id_]['error']))
             raise BrowserError(self.messages[id_]['error'])
         else:
             return self.messages[id_]['result']

--- a/puppy/utils.py
+++ b/puppy/utils.py
@@ -1,0 +1,15 @@
+import gc
+import socket
+
+
+def get_free_port():
+    """Get free port."""
+
+    # This is how pyppeteer does it
+    sock = socket.socket()
+    sock.bind(('localhost', 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    del sock
+    gc.collect()
+    return port


### PR DESCRIPTION
- Implemented puppeteer page methods:
  - click()
  - close()
  - content()
  - document
  - evaluate()
  - evaluate_on_new_document()
  - focus()
  - reload()
  - select()
  - xpath()
  - type()
  - url()
  - wait_for_navigation()
  - wait_for_xpath()
  - xpath()
- Browser class accepts proxy_uri, user_agent, and additional command line args
- chromium_downloader works on mac and linux

With these changes, I *think* this is enough to integrate with scraping_tools and try as a replacement for pyppeteer.

cc @spulec 